### PR TITLE
I don't understand how does it work.

### DIFF
--- a/content/blog/setup-vscode-to-run-debug-c-cpp-code/index.md
+++ b/content/blog/setup-vscode-to-run-debug-c-cpp-code/index.md
@@ -157,7 +157,7 @@ Notice that I’ve added one more optional configuration `g++ build & run active
   "version":
 }
 ```
-
+here
 > `externalConsole` in `launch.json` can be set to true to see code output in cmd instead.
 
 **Restart VSCode** to take effects of newly added compiler paths.


### PR DESCRIPTION
 My C program don't compile and run.  I think becouse of instead of .exe extansion file had .out exatnsion. And so on.